### PR TITLE
Fix Minio public permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,13 @@ The `browserless` container is a virtual web browser that is used to scrape reci
 
 The `ingredient-instruction-classifier` container facilitates machine learning classification of ingredients and instructions, which is used to improve accuracy during the "autofill" feature. Without it, the recipe _should still work_, but will be a bit less accurate or may not be able to pull ingredients or instructions from poorly formatted webpages.
 
-The `minio` container 
+The `minio` container stores photos/images for the recipes. It could be replaced with AWS's S3 service if preferred. 
 
 ## Changelog
+
+### v1.1.1
+
+Fix public access permissions for new minio installations. 
 
 ### v1.1.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       "
       /usr/bin/mc config host add myminio http://minio:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY;
       /usr/bin/mc mb myminio/recipesage-selfhost;
-      /usr/bin/mc policy set public myminio/recipesage-selfhost;
+      /usr/bin/mc anonymous set download myminio/recipesage-selfhost;
       exit 0;
       "
 volumes:


### PR DESCRIPTION
MinIO appears to have deprecated the `mc policy` subcommand and now wants you to use `mc anonymous`. https://min.io/docs/minio/linux/reference/minio-mc.html

Seeing the follow error with 'create-minio-buckets' container when starting from a fresh minio install. 

```
create-minio-buckets_1               | mc: Please use 'mc anonymous'
```

Also adds details about what minio is used for.