### PR TITLE
Improve podman support

### DIFF
--- a/proxy.conf
+++ b/proxy.conf
@@ -6,7 +6,6 @@ server {
 	server_name localhost;
 
   location /grip/ws {
-    resolver 127.0.0.11 valid=30s;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
@@ -20,18 +19,15 @@ server {
   # Alias minio in case minio container is not present
   set $minio http://minio:9000;
   location /minio/ {
-    resolver 127.0.0.11 valid=30s;
     rewrite ^/minio/(.*)$ /$1 break;
     proxy_pass $minio;
   }
 
   location /api/ {
-    resolver 127.0.0.11 valid=30s;
     proxy_pass http://api:3000/;
   }
 
 	location / {
-    resolver 127.0.0.11 valid=30s;
     proxy_pass http://static:80/;
 	}
 }


### PR DESCRIPTION
The line `resolver 127.0.0.11` in the nginx conf breaks the podman DNS.
Podman does not use 127.0.0.11 as the DNS resolver. Podman generally does not run a DNS server on the host for container DNS resolution. Instead, it typically relies on the host's DNS settings, which are propagated into the container.

Podman configures each container to use the host machine's /etc/resolv.conf for DNS resolution by default. So, the DNS resolver settings would usually be the same as those of the host system.

In a Podman setup, you would commonly leave the resolver directive out or set it to the DNS server that you want the Nginx instance to use for resolution, which could be an external DNS server or a custom DNS service running in another container. If you're running a custom DNS service, you would specify its IP address.

I have checked other repositories that use nginx to proxy different docker containers and the `resolver 127.0.0.11` is not present.  From there I assume this line is not necessary for docker either. Of course, someone would have to confirm this assumption. If I am wrong, we can simply leave it as is with some comment aimed at podman users to remove these particular lines.