### PR TITLE
fix: add missing dependency on `valkey` in api service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
         condition: service_healthy
       pushpin:
         condition: service_started
+      valkey:
+        condition: service_started
     command: ./scripts/selfhost-startup.sh
     environment:
       <<: *common-env


### PR DESCRIPTION
ISSUE CLOSED: #112